### PR TITLE
tests: Add sample-test.bats, environment.bash

### DIFF
--- a/tests/environment.bash
+++ b/tests/environment.bash
@@ -1,0 +1,34 @@
+. "$_GO_CORE_DIR/lib/testing/environment"
+. "$_GO_CORE_DIR/lib/bats/assertions"
+
+set_bats_test_suite_name "${BASH_SOURCE[0]%/*}"
+remove_bats_test_dirs
+
+mirror_repo_into_test_go_rootdir() {
+  . "$_GO_USE_MODULES" 'fileutil'
+  @go.mirror_directory "$_GO_ROOTDIR" "$TEST_GO_ROOTDIR"
+}
+
+parse_navigation_menu() {
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  __parse_navigation_menu
+  restore_bats_shell_options "$?"
+}
+
+__parse_navigation_menu() {
+  local line
+  local in_nav_menu=''
+  lines=()
+
+  while IFS= read -r line; do
+    line="${line%$'\r'}"
+    if [[ -n "$in_nav_menu" ]]; then
+      if [[ -z "$line" ]]; then
+        break
+      fi
+      lines+=("$line")
+    elif [[ "$line" == 'navigation:' ]]; then
+      in_nav_menu='true'
+    fi
+  done <"$TEST_GO_ROOTDIR/_config.yml"
+}

--- a/tests/sample-test.bats
+++ b/tests/sample-test.bats
@@ -1,0 +1,23 @@
+#! /usr/bin/env bats
+#
+# Feel free to update this file and environment.bash with any Bash/Bats based
+# tests you'd like to add to your project.
+
+load environment
+
+TEST_LOG_PATTERN=
+
+setup() {
+  test_filter
+  mirror_repo_into_test_go_rootdir
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: sample test" {
+  run "$TEST_GO_ROOTDIR/go" 'help'
+  assert_success
+  assert_output_matches "Usage: $TEST_GO_ROOTDIR/go"
+}


### PR DESCRIPTION
This works around the problem of ./go setup failing when there aren't any tests by making sure there's a sample Bats test left behind by default.
